### PR TITLE
docs(readme): added MIT license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,8 @@ This app follows the **MVVM (Model-View-ViewModel)** architecture pattern:
 - **Coroutines**: For handling asynchronous operations.
 - **Material3**: For UI components and design system.
 
+## License
+
+This project is licensed under the [MIT License](./License.md).
+
 


### PR DESCRIPTION
Title:
docs(readme): add dedicated MIT License section

Description:
This pull request enhances the project documentation by adding a dedicated MIT License section to the README.

Changes Introduced:
Added a clear and visible License section in the README.
Linked the section to the full LICENSE file for easy access.
Improved the wording to align with standard open-source practices.

Benefits:
Improves transparency regarding project licensing.
Makes it easier for contributors and users to understand their rights and obligations.
Strengthens open-source compliance.

Linked Issue:
Fixes #11 

Additional Notes:
This change is documentation-only and does not affect application functionality.

Author
@vinitjain2005

Screenshot
<img width="622" height="172" alt="Screenshot 2025-08-15 151522" src="https://github.com/user-attachments/assets/8edae26b-7368-485e-b563-7d73fa74fc44" />
